### PR TITLE
Increase client_max_body_size to 20M

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,9 @@ http {
   default_type application/octet-stream;
 
   sendfile on;
-
+  
+  client_max_body_size 20M;
+  
   keepalive_timeout 65;
 
   include /etc/nginx/sites-enabled/*;

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,8 +12,6 @@ http {
 
   sendfile on;
   
-  client_max_body_size 20M;
-  
   keepalive_timeout 65;
 
   include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
To prevent "ugly" server error and instead allow web server code to output more meaningful error message.