### PR TITLE
Feature/414 mitigation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Jonathan Baker <chessracer@gmail.com>
 
 RUN apk --update add \
   nginx \
-  nano \
   php-pgsql \
   php-fpm \
   php-pdo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Jonathan Baker <chessracer@gmail.com>
 
 RUN apk --update add \
   nginx \
+  nano \
   php-pgsql \
   php-fpm \
   php-pdo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM orukami/alpine-php:5.6
 MAINTAINER Jonathan Baker <chessracer@gmail.com>
 
+ENV TERM xterm
+
 RUN apk --update add \
   nginx \
   nano \

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,7 @@ http {
 
   sendfile on;
 
-  client_max_body_size 12M;
+  client_max_body_size 120M;
   
   keepalive_timeout 65;
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,9 @@ http {
   default_type application/octet-stream;
 
   sendfile on;
-
+  
+  client_max_body_size 20M;
+  
   keepalive_timeout 65;
 
   include /etc/nginx/sites-enabled/*;

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,8 +11,8 @@ http {
   default_type application/octet-stream;
 
   sendfile on;
-  
-  client_max_body_size 20M;
+
+  client_max_body_size 0;
   
   keepalive_timeout 65;
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,7 +12,7 @@ http {
 
   sendfile on;
 
-  client_max_body_size 0;
+  client_max_body_size 12M;
   
   keepalive_timeout 65;
 

--- a/php.ini
+++ b/php.ini
@@ -1,4 +1,5 @@
 upload_max_filesize=8M
+post_max_size=12M
 max_executionn_time=600
 memory_limit=512M
 error_reporting=1

--- a/php.ini
+++ b/php.ini
@@ -1,5 +1,5 @@
 upload_max_filesize=8M
-post_max_size=12M
+post_max_size=150M
 max_executionn_time=600
 memory_limit=512M
 error_reporting=1


### PR DESCRIPTION
This has new values for post_max_size in php.ini, and client_max_body_size in ngnix.conf.  Plus it has the nano editor.  I also added ENV TERN xterm so that nano can run without having to prepend that command when running nano.

The main purpose of php and nginx changes is to make reporting of file size error more user friendly.